### PR TITLE
Remove hasImage (Twitter no longer counts images in character count)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/mscoutermarsh/tweet-characters-left.svg?branch=master)](https://travis-ci.org/mscoutermarsh/tweet-characters-left)
 [![Code Climate](https://codeclimate.com/github/mscoutermarsh/tweet-characters-left/badges/gpa.svg)](https://codeclimate.com/github/mscoutermarsh/tweet-characters-left)
 
-A Node module for determining the number of characters left in a tweet. It uses Twitter's official TwitterText library to count characters. Includes option to leave space for images.
+A Node module for determining the number of characters left in a tweet. It uses Twitter's official TwitterText library to count characters.
 
 ## Installation
 ```Bash
@@ -17,13 +17,7 @@ var tweetCharactersLeft = require("tweet-characters-left");
 // Twitters most common tweet
 tweetCharactersLeft("Bieber! Marry me!");
 // => 123
-
-// We can also leave space for an image
-tweetCharactersLeft("Bieber! Marry me!", { hasImage: true });
-// => 99
 ```
-
-Note: Twitter uses 24 characters for 1 or more images. This works for any number of image attachments.
 
 ## Tests
 ```Bash

--- a/example.js
+++ b/example.js
@@ -2,6 +2,3 @@ var tweetCharactersLeft = require("tweet-characters-left");
 
 // Twitters most common tweet.
 console.log(tweetCharactersLeft("Bieber! Marry me!"));
-
-// If we also included an image.
-console.log(tweetCharactersLeft("Bieber! Marry me!", { hasImage: true }));

--- a/index.js
+++ b/index.js
@@ -1,15 +1,7 @@
 const twitterText = require('twitter-text');
 
 const TWEET_LENGTH = 140;
-const IMAGE_ATTACHMENT_LENGTH = 24;
 
-module.exports = function tweetCharactersLeft(text, options) {
-  var options = options || {};
-  var charsLeft = TWEET_LENGTH;
-
-  if (options.hasImage === true) {
-    charsLeft -= IMAGE_ATTACHMENT_LENGTH;
-  }
-
-  return charsLeft - twitterText.getTweetLength(text);
+module.exports = function tweetCharactersLeft(text) {
+  return TWEET_LENGTH - twitterText.getTweetLength(text);
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tweet-characters-left",
-  "version": "1.0.1",
-  "description": "Node.js package for determining the number of characters left in a tweet. Supports character counts for tweets with images. Uses Twitter's official TwitterText package for counting characters.",
+  "version": "2.0.0",
+  "description": "Node.js package for determining the number of characters left in a tweet. Uses Twitter's official TwitterText package for counting characters.",
   "main": "index.js",
   "tonicExampleFilename": "example.js",
   "scripts": {
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/mscoutermarsh/tweet-characters-left#readme",
   "dependencies": {
-    "twitter-text": "^1.13.2"
+    "twitter-text": "^1.14.3"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/test/index.js
+++ b/test/index.js
@@ -14,12 +14,8 @@ describe('tweetCharactersLeft', function() {
     expect(tweetCharactersLeft('https://www.producthunt.com')).to.eq(117);
   });
 
-  it('can leave space for image attachments', () => {
-    expect(tweetCharactersLeft('', { hasImage: true })).to.eq(116);
-  });
-
   it('handles negative numbers', () => {
     var longTweet = Array(100).join('abc');
-    expect(tweetCharactersLeft(longTweet, { hasImage: true })).to.eq(-181);
+    expect(tweetCharactersLeft(longTweet)).to.eq(-157);
   });
 });


### PR DESCRIPTION
- Bumping to latest version of twitter text
- Removing `hasImage` since Twitter no longer counts images towards the character count
- Bumping to version 2.0 since this is a breaking change.