### PR TITLE
Updating for 280 character tweets and deprecated call

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ var tweetCharactersLeft = require("tweet-characters-left");
 
 // Twitters most common tweet
 tweetCharactersLeft("Bieber! Marry me!");
-// => 123
+// => 263
 ```
 
 ## Tests

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const twitterText = require('twitter-text');
 
-const TWEET_LENGTH = 140;
+const TWEET_LENGTH = 280;
 
 module.exports = function tweetCharactersLeft(text) {
   return TWEET_LENGTH - twitterText.parseTweet(text).weightedLength;

--- a/index.js
+++ b/index.js
@@ -3,5 +3,5 @@ const twitterText = require('twitter-text');
 const TWEET_LENGTH = 140;
 
 module.exports = function tweetCharactersLeft(text) {
-  return TWEET_LENGTH - twitterText.getTweetLength(text);
+  return TWEET_LENGTH - twitterText.parseTweet(text).weightedLength;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tweet-characters-left",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Node.js package for determining the number of characters left in a tweet. Uses Twitter's official TwitterText package for counting characters.",
   "main": "index.js",
   "tonicExampleFilename": "example.js",
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/mscoutermarsh/tweet-characters-left#readme",
   "dependencies": {
-    "twitter-text": "^1.14.3"
+    "twitter-text": "^2.0.4"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/test/index.js
+++ b/test/index.js
@@ -3,19 +3,19 @@ var expect = require('chai').expect,
 
 describe('tweetCharactersLeft', function() {
   it('returns number of chars left in a tweet', () => {
-    expect(tweetCharactersLeft('Bieber, marry me!')).to.eq(123);
+    expect(tweetCharactersLeft('Bieber, marry me!')).to.eq(263);
   });
 
   it('returns the max chars if no message', () => {
-    expect(tweetCharactersLeft('')).to.eq(140);
+    expect(tweetCharactersLeft('')).to.eq(280);
   });
 
   it('shortens links', () => {
-    expect(tweetCharactersLeft('https://www.producthunt.com')).to.eq(117);
+    expect(tweetCharactersLeft('https://www.producthunt.com')).to.eq(257);
   });
 
   it('handles negative numbers', () => {
     var longTweet = Array(100).join('abc');
-    expect(tweetCharactersLeft(longTweet)).to.eq(-157);
+    expect(tweetCharactersLeft(longTweet)).to.eq(-17);
   });
 });


### PR DESCRIPTION
Hi! I've got two changes proposed here:

- Updating to the new 280-character limit
- Updating to latest twitter-text and switching away from the deprecated `getTweetLength` method

Let me know if you have any questions! 🎉 